### PR TITLE
fix(build) Use pip module during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ virtualenv --python=python3.6 venv
 source venv/bin/activate
 
 log "Install Python packages in requirements.txt..."
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 # Collect Django's static files.
 log "Running 'manage.py collectstatic' to collect static files."

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ error() {
   else
     echo "deploy.sh experienced an error on line ${line_lo}; exiting with status ${code}"
   fi
-  
+
   exit 1
 }
 
@@ -17,7 +17,7 @@ DEPLOYMENT_PATH='/var/www/app'
 LOGS_PATH='/var/log/app'
 
 # Stops the execution of the script if any command, including pipes, fail.
-set -e 
+set -e
 set -o pipefail
 trap 'error ${LINENO}' ERR
 
@@ -55,7 +55,7 @@ source venv/bin/activate
 
 # Install Python packages in requirements.txt.
 echo "Install Python packages in requirements.txt..."
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 # Apply Django's migrations.
 echo "Running manage.py migrate to apply migrations."


### PR DESCRIPTION
Use `python -m pip` instead of `pip` during build to avoid breaking the build when the path in which the venv exists is too long.

Issue #404